### PR TITLE
Feat/resume skills

### DIFF
--- a/src/pages/projects/Projects.tsx
+++ b/src/pages/projects/Projects.tsx
@@ -4,12 +4,12 @@ import { useLanguage } from '../../contexts/LanguageContext';
 import ProjectCard from './components/ProjectCard';
 import ProjectDialog from './components/ProjectDialog';
 import { projectsDataEn } from './data/projectsData.en';
-import { projectsDataFR } from './data/projectsData.fr';
+import { projectsDataFr } from './data/projectsData.fr';
 import type { ProjectProps } from './data/projectsDataType';
 
 const Projects = () => {
   const { language } = useLanguage();
-  const projectsList = language === 'en' ? projectsDataEn : projectsDataFR;
+  const projectsList = language === 'en' ? projectsDataEn : projectsDataFr;
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [focusedProject, setFocusedProject] = useState<ProjectProps | null>(null);
 

--- a/src/pages/projects/components/ProjectDialog.tsx
+++ b/src/pages/projects/components/ProjectDialog.tsx
@@ -41,7 +41,7 @@ const ProjectDialog = ({ isOpen, setIsOpen, focusedProject }: ProjectDialogProps
         <DialogPanel className="border-primary bg-global-secondary max-h-[80dvh] max-w-4xl space-y-4 overflow-y-auto rounded-2xl border-3 p-3 sm:p-8 lg:p-12">
           {/* Title and button */}
           <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
-            <DialogTitle className="text-primary transition-theme border-accent-light dark:border-accent-dark rounded-sm border-2 p-2 font-bold uppercase hover:shadow-[0_0_12px_4px_var(--color-btn-primary-hover-light)] motion-reduce:transition-none dark:hover:shadow-[0_0_12px_4px_var(--color-btn-primary-hover-dark)]">
+            <DialogTitle className="text-primary transition-theme border-accent-light dark:border-accent-dark rounded-sm border-2 p-2 font-bold uppercase motion-reduce:transition-none">
               {focusedProject?.name}
             </DialogTitle>
 

--- a/src/pages/projects/data/projectsData.en.ts
+++ b/src/pages/projects/data/projectsData.en.ts
@@ -20,7 +20,7 @@ export const projectsDataEn: ProjectProps[] = [
       },
       {
         name: 'Tools',
-        content: ['Motion', 'ESLint', 'Prettier', 'Vite', 'Excalidraw', 'HeadlessUI'],
+        content: ['Framer Motion', 'ESLint', 'Prettier', 'Vite', 'Excalidraw', 'HeadlessUI'],
       },
     ],
     tags: ['Portfolio', 'Frontend', 'Tailwind', 'Solo project'],

--- a/src/pages/projects/data/projectsData.en.ts
+++ b/src/pages/projects/data/projectsData.en.ts
@@ -11,16 +11,33 @@ export const projectsDataEn: ProjectProps[] = [
       'Developed entirely solo, this site highlights my skills, background, and projects. I used Tailwind and a reusable component structure for a clean, modern, scalable, and accessible result.',
     stack: [
       {
+        category: 'language',
         name: 'Languages',
-        content: ['HTML', 'CSS', 'JavaScript'],
+        content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
         content: ['React', 'Tailwind'],
       },
       {
+        category: 'tool',
         name: 'Tools',
-        content: ['Framer Motion', 'ESLint', 'Prettier', 'Vite', 'Excalidraw', 'HeadlessUI'],
+        content: [
+          'Framer Motion',
+          'ESLint',
+          'Prettier',
+          'Vite',
+          'Excalidraw',
+          'HeadlessUI',
+          'Git',
+          'Github',
+        ],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility', 'REST API'],
       },
     ],
     tags: ['Portfolio', 'Frontend', 'Tailwind', 'Solo project'],
@@ -49,20 +66,29 @@ export const projectsDataEn: ProjectProps[] = [
       'Full-stack project developed by a team of four web developers during our training program. Inspired by classic platforms, this app enhances the user experience with nutritional and environmental ratings, multi-level account access (visitor, free user, premium user, admin), and personalized features. Built to be scalable, it follows a clean monorepo architecture using external APIs and modern technologies.',
     stack: [
       {
+        category: 'language',
         name: 'Languages',
         content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
-        content: ['React', 'Express'],
+        content: ['React', 'Express', 'Node'],
       },
       {
+        category: 'database',
         name: 'Databases',
         content: ['MySQL'],
       },
       {
+        category: 'tool',
         name: 'Tools',
-        content: ['Biome', 'Monorepo', 'Excalidraw', 'Figma'],
+        content: ['Biome', 'Monorepo', 'Excalidraw', 'Figma', 'Git', 'Github'],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility', 'Agile', 'REST API'],
       },
     ],
     tags: ['Full Stack', 'Team Project', 'Recipes', 'Sustainability', 'Nutrition', 'Ecology'],
@@ -89,16 +115,24 @@ export const projectsDataEn: ProjectProps[] = [
       'Built during an internal hackathon, CodeWarts is a fun app to learn coding through themed quizzes inspired by the Harry Potter universe with nods to our instructors. The team delivered a functional MVP in 48 hours, with routing and dynamic quiz display.',
     stack: [
       {
+        category: 'language',
         name: 'Languages',
-        content: ['HTML', 'CSS', 'JavaScript'],
+        content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
         content: ['React'],
       },
       {
+        category: 'tool',
         name: 'Tools',
-        content: ['Biome', 'Vite'],
+        content: ['Biome', 'Vite', 'Git', 'Github'],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility'],
       },
     ],
     tags: ['Quiz', 'Hackathon', 'Code', 'Harry Potter', 'Fun'],
@@ -128,14 +162,17 @@ export const projectsDataEn: ProjectProps[] = [
       'Group project built around the concept of international cooking. The interface is centered on an interactive map that allows users to access country-specific recipes from an external API. I independently handled the map implementation, responsive design, country selection logic, and bug fixing. I also contributed to the initial project idea, the API selection, and the overall UI/UX design.',
     stack: [
       {
+        category: 'language',
         name: 'Languages',
-        content: ['HTML', 'CSS', 'JavaScript'],
+        content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
         content: ['React'],
       },
       {
+        category: 'tool',
         name: 'Tools',
         content: [
           'Biome',
@@ -146,7 +183,14 @@ export const projectsDataEn: ProjectProps[] = [
           'Fetch API',
           'React Simple Maps',
           'ThemealDB',
+          'Git',
+          'Github',
         ],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility', 'Agile', 'REST API'],
       },
     ],
     tags: ['Recipes', 'API', 'Interactive map', 'International'],
@@ -173,16 +217,24 @@ export const projectsDataEn: ProjectProps[] = [
       'Built solo during a 3-hours open workshop, this project aimed to practice using Fetch. I intentionally made it more complex by choosing non-standard stations data (CSV) to generate an interactive weather interface. The weather display algorithm is partially implemented.',
     stack: [
       {
+        category: 'language',
         name: 'Languages',
-        content: ['HTML', 'CSS', 'JavaScript'],
+        content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
         content: ['React'],
       },
       {
+        category: 'tool',
         name: 'Tools',
-        content: ['Biome', 'Vite'],
+        content: ['Biome', 'Vite', 'Git', 'Github'],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility', 'REST API'],
       },
     ],
     tags: ['Weather', 'Fetch', 'CSV', 'React', 'Quick project'],
@@ -208,16 +260,24 @@ export const projectsDataEn: ProjectProps[] = [
       'This project involved quickly integrating an API and organizing information in a clear React interface. Built in a duo in one day, it highlights rapid structuring and dynamic data rendering.',
     stack: [
       {
+        category: 'language',
         name: 'Languages',
-        content: ['HTML', 'CSS', 'JavaScript'],
+        content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
         content: ['React'],
       },
       {
+        category: 'tool',
         name: 'Tools',
-        content: ['Biome', 'Vite', 'Fetch API'],
+        content: ['Biome', 'Vite', 'Fetch API', 'Git', 'Github'],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility', 'REST API'],
       },
     ],
     tags: ['Planets', 'API', 'React', 'Space data'],
@@ -243,12 +303,19 @@ export const projectsDataEn: ProjectProps[] = [
       'Group project initiated after only three weeks of training. In the group version, I developed the overall structure, header, footer, global style, quiz algorithm, and all sets of questions. I later took over the codebase on my own to offer a cleaner version focused on the essentials: the homepage and the quiz. I kept the parts I had written, removed two pages and recoded the homepage for a more professional look.',
     stack: [
       {
+        category: 'language',
         name: 'Languages',
         content: ['HTML', 'CSS', 'JavaScript'],
       },
       {
+        category: 'tool',
         name: 'Tools',
-        content: ['Biome', 'Excalidraw', 'Figma'],
+        content: ['Biome', 'Excalidraw', 'Figma', 'Git', 'Github'],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility', 'Agile'],
       },
     ],
     tags: ['Quiz', 'Algorithm', 'Revamp', 'Dark/Light mode', 'Responsive'],

--- a/src/pages/projects/data/projectsData.fr.ts
+++ b/src/pages/projects/data/projectsData.fr.ts
@@ -1,6 +1,6 @@
 import type { ProjectProps } from './projectsDataType';
 
-export const projectsDataFR: ProjectProps[] = [
+export const projectsDataFr: ProjectProps[] = [
   {
     id: 'portfolio',
     name: 'Portfolio personnel',
@@ -20,7 +20,7 @@ export const projectsDataFR: ProjectProps[] = [
       },
       {
         name: 'Tools',
-        content: ['Motion', 'ESLint', 'Prettier', 'Vite', 'Excalidraw', 'HeadlessUI'],
+        content: ['Framer Motion', 'ESLint', 'Prettier', 'Vite', 'Excalidraw', 'HeadlessUI'],
       },
     ],
     tags: ['Portfolio', 'Frontend', 'Tailwind', 'Projet solo'],

--- a/src/pages/projects/data/projectsData.fr.ts
+++ b/src/pages/projects/data/projectsData.fr.ts
@@ -11,16 +11,33 @@ export const projectsDataFr: ProjectProps[] = [
       'Développé entièrement en solo, ce site met en avant mes compétences, mon parcours et mes projets. J’y ai intégré Tailwind et organisé une structure de composants réutilisables pour un rendu clair, moderne, scalable et accessible.',
     stack: [
       {
+        category: 'language',
         name: 'Languages',
-        content: ['HTML', 'CSS', 'JavaScript'],
+        content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
         content: ['React', 'Tailwind'],
       },
       {
+        category: 'tool',
         name: 'Tools',
-        content: ['Framer Motion', 'ESLint', 'Prettier', 'Vite', 'Excalidraw', 'HeadlessUI'],
+        content: [
+          'Framer Motion',
+          'ESLint',
+          'Prettier',
+          'Vite',
+          'Excalidraw',
+          'HeadlessUI',
+          'Git',
+          'Github',
+        ],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility', 'REST API'],
       },
     ],
     tags: ['Portfolio', 'Frontend', 'Tailwind', 'Projet solo'],
@@ -49,20 +66,29 @@ export const projectsDataFr: ProjectProps[] = [
       'Projet full stack réalisé en équipe de 4 développeurs en formation. Inspiré des sites de recettes classiques, cette application pousse plus loin l’expérience utilisateur grâce à une notation nutritionnelle et environnementale, une gestion de compte multi-niveaux (visiteur, abonné, premium, admin), et des fonctionnalités personnalisées. Le projet est conçu pour être scalable, structuré autour d’un monorepo avec des API externes et une architecture propre.',
     stack: [
       {
+        category: 'language',
         name: 'Languages',
         content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
-        content: ['React', 'Express'],
+        content: ['React', 'Express', 'Node'],
       },
       {
+        category: 'database',
         name: 'Databases',
         content: ['MySQL'],
       },
       {
+        category: 'tool',
         name: 'Tools',
-        content: ['Biome', 'Monorepo', 'Excalidraw', 'Figma'],
+        content: ['Biome', 'Monorepo', 'Excalidraw', 'Figma', 'Git', 'Github'],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility', 'Agile', 'REST API'],
       },
     ],
     tags: ['Full Stack', 'Projet en équipe', 'Recettes', 'Responsable', 'Nutrition', 'Écologie'],
@@ -90,16 +116,24 @@ export const projectsDataFr: ProjectProps[] = [
       "Conçu lors d’un hackathon interne à la promo, CodeWarts est une application fun pour apprendre à coder en répondant à des quiz dans un univers inspiré d’Harry Potter avec des clins d'oeil à nos formateurs. L’équipe a livré un MVP fonctionnel en 48h avec routes et affichage dynamique.",
     stack: [
       {
+        category: 'language',
         name: 'Languages',
-        content: ['HTML', 'CSS', 'JavaScript'],
+        content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
         content: ['React'],
       },
       {
+        category: 'tool',
         name: 'Tools',
-        content: ['Biome', 'Vite'],
+        content: ['Biome', 'Vite', 'Git', 'Github'],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility'],
       },
     ],
     tags: ['Quiz', 'Hackathon', 'Code', 'Harry Potter', 'Fun'],
@@ -129,14 +163,17 @@ export const projectsDataFr: ProjectProps[] = [
       'Application de groupe réalisée autour d’un concept de cuisine internationale. L’interface est centrée sur une carte interactive permettant d’accéder à des recettes par pays, issues d’une API externe. J’ai pris en charge seul la carte, le responsive, la sélection de pays et la résolution de bugs. J’ai également contribué à l’idée initiale du projet, à la recherche de l’API adaptée et à la co-conception du design global.',
     stack: [
       {
+        category: 'language',
         name: 'Languages',
-        content: ['HTML', 'CSS', 'JavaScript'],
+        content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
         content: ['React'],
       },
       {
+        category: 'tool',
         name: 'Tools',
         content: [
           'Biome',
@@ -147,7 +184,14 @@ export const projectsDataFr: ProjectProps[] = [
           'Fetch API',
           'React Simple Maps',
           'ThemealDB',
+          'Git',
+          'Github',
         ],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility', 'Agile', 'REST API'],
       },
     ],
     tags: ['Recettes', 'API', 'Carte interactive', 'International'],
@@ -176,16 +220,24 @@ export const projectsDataFr: ProjectProps[] = [
       "Réalisé en autonomie pendant un atelier libre de 3h, ce projet visait à apprendre à utiliser Fetch. J'ai volontairement choisi de le complexifier avec des données de stations non classiques (CSV) pour générer une interface météo interactive. L’algorithme d’affichage météo est partiellement implémenté.",
     stack: [
       {
+        category: 'language',
         name: 'Languages',
-        content: ['HTML', 'CSS', 'JavaScript'],
+        content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
         content: ['React'],
       },
       {
+        category: 'tool',
         name: 'Tools',
-        content: ['Biome', 'Vite'],
+        content: ['Biome', 'Vite', 'Git', 'Github'],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility', 'REST API'],
       },
     ],
     tags: ['Météo', 'Fetch', 'CSV', 'React', 'Projet rapide'],
@@ -210,16 +262,24 @@ export const projectsDataFr: ProjectProps[] = [
     detailedDescription: `Ce projet consistait à intégrer rapidement une API et structurer l'information dans une interface React claire. Réalisé en binôme en une journée, il met en valeur la structuration et l'affichage dynamique de données.`,
     stack: [
       {
+        category: 'language',
         name: 'Languages',
-        content: ['HTML', 'CSS', 'JavaScript'],
+        content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
         content: ['React'],
       },
       {
+        category: 'tool',
         name: 'Tools',
-        content: ['Biome', 'Vite', 'Fetch API'],
+        content: ['Biome', 'Vite', 'Fetch API', 'Git', 'Github'],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility', 'REST API'],
       },
     ],
     tags: ['Planètes', 'API', 'React', 'Données spatiales'],
@@ -245,12 +305,19 @@ export const projectsDataFr: ProjectProps[] = [
       "Travail de groupe réalisé après seulement trois semaines de formation. Au sein du projet de groupe, j'avais développé la structure globale, header, footer, le style global, l’algo du quiz et les sets de questions. J’ai ensuite repris le code en solo pour proposer une version plus propre et recentrée sur l’essentiel : la page d’accueil et le quiz. J’ai conservé les parties que j'avais codées, supprimé deux pages, puis recodé la page d'acceuil pour un rendu professionnel.",
     stack: [
       {
+        category: 'language',
         name: 'Languages',
         content: ['HTML', 'CSS', 'JavaScript'],
       },
       {
+        category: 'tool',
         name: 'Tools',
-        content: ['Biome', 'Excalidraw', 'Figma'],
+        content: ['Biome', 'Excalidraw', 'Figma', 'Git', 'Github'],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility', 'Agile'],
       },
     ],
     tags: ['Quiz', 'Algo', 'Refonte', 'Dark/Light mode', 'Responsive'],

--- a/src/pages/projects/data/projectsDataType.ts
+++ b/src/pages/projects/data/projectsDataType.ts
@@ -37,10 +37,3 @@ export interface ProjectLinksProps {
   demoLink: string | undefined;
   repoLink: string | undefined;
 }
-
-export interface TechMap {
-  [key: string]: {
-    label: string;
-    projects: string[];
-  };
-}

--- a/src/pages/projects/data/projectsDataType.ts
+++ b/src/pages/projects/data/projectsDataType.ts
@@ -37,3 +37,10 @@ export interface ProjectLinksProps {
   demoLink: string | undefined;
   repoLink: string | undefined;
 }
+
+export interface TechMap {
+  [key: string]: {
+    label: string;
+    projects: string[];
+  };
+}

--- a/src/pages/resume/Resume.tsx
+++ b/src/pages/resume/Resume.tsx
@@ -16,12 +16,13 @@ const Resume = () => {
         <h2 className="transition-theme border-primary my-2 w-full border-b-2 pb-2 text-xl font-bold motion-reduce:transition-none">
           {language === 'en' ? 'My journey' : 'Mon parcours'}
         </h2>
-        <div className="grid gap-2 md:grid-cols-2">
-          <WorkExperiences className="md:col-start-2 md:row-start-1" />
-          <Skills className="md:col-start-1 md:row-start-1" />
-          <Education className="md:col-start-2 md:row-start-2" />
-          <SoftSkills className="md:col-start-1 md:row-start-2" />
-          <Languages className="md:col-span-2 md:row-start-3" />
+        <div className="lg:grid-row-6 grid gap-2 md:grid-cols-2 md:grid-rows-8 lg:grid-rows-7">
+          {' '}
+          <WorkExperiences className="md:col-start-2 md:row-span-3 md:row-start-1" />
+          <Skills className="md:col-start-1 md:row-span-7 md:row-start-1 lg:row-span-5" />
+          <Education className="md:col-start-2 md:row-span-2 md:row-start-4" />
+          <SoftSkills className="md:col-start-2 md:row-span-2 md:row-start-6 lg:col-span-2 lg:row-span-1 lg:row-start-6" />
+          <Languages className="md:col-span-2 md:row-start-8 lg:row-start-7" />
         </div>
       </section>
     </div>

--- a/src/pages/resume/components/Skills.tsx
+++ b/src/pages/resume/components/Skills.tsx
@@ -1,6 +1,9 @@
 import { motion, useInView, useReducedMotion } from 'motion/react';
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { useLanguage } from '../../../contexts/LanguageContext';
+import { projectsDataEn } from '../../projects/data/projectsData.en';
+import { projectsDataFr } from '../../projects/data/projectsData.fr';
+import type { TechMap } from '../../projects/data/projectsDataType';
 import { skillsDataEN } from '../data/profileData.en';
 import { skillsDataFR } from '../data/profileData.fr';
 import type { SkillsProps } from '../data/profileDataType';
@@ -9,8 +12,52 @@ const Skills = ({ className }: SkillsProps) => {
   const shouldReduceMotion = useReducedMotion();
   const { language } = useLanguage();
   const skillsList = language === 'en' ? skillsDataEN : skillsDataFR;
+  const projectsList = language === 'en' ? projectsDataEn : projectsDataFr;
+
+  /* Animations */
+
   const sectionRef = useRef(null);
   const isInView = useInView(sectionRef, { amount: 0.2, once: true });
+
+  const animatedList = {
+    hidden: { opacity: 0 },
+    visible: {
+      opacity: 1,
+      transition: {
+        staggerChildren: 0.1,
+      },
+    },
+  };
+
+  const animatedListItem = {
+    hidden: { opacity: 0, y: 10 },
+    visible: { opacity: 1, y: 0 },
+  };
+
+  /* Projects - TechMap */
+
+  const technologiesMap = useMemo(() => {
+    const techMap: TechMap = {};
+
+    for (const project of projectsList) {
+      for (const technology of project.stack) {
+        for (const item of technology.content) {
+          for (const skill of skillsList) {
+            if (!techMap[skill.id]) {
+              techMap[skill.id] = { label: skill.label, projects: [] };
+            }
+            if (item.toLowerCase() === skill.id) {
+              if (!techMap[skill.id].projects.includes(project.name)) {
+                techMap[skill.id].projects.push(project.name);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return Object.entries(techMap);
+  }, [skillsList, projectsList]);
 
   return (
     <motion.section
@@ -20,6 +67,50 @@ const Skills = ({ className }: SkillsProps) => {
       <h3 className="border-b-accent-light dark:border-b-accent-dark transition-theme mb-4 w-fit border-b-2 font-bold motion-reduce:transition-none">
         {language === 'en' ? 'Skills' : 'Compétences'}
       </h3>
+      {/* V2 - Projects display */}
+      <motion.ul
+        className="grid grid-cols-2 gap-2"
+        variants={shouldReduceMotion ? undefined : animatedList}
+        initial="hidden"
+        animate={isInView ? 'visible' : 'hidden'}
+      >
+        {technologiesMap.map(([id, skill]) => {
+          const maxProjectsDisplayed = 2;
+          const displayedProjects = skill.projects.slice(0, maxProjectsDisplayed);
+          const extraCount = Math.max(skill.projects.length - maxProjectsDisplayed, 0);
+
+          return (
+            <motion.li
+              key={id}
+              className="py-2"
+              variants={animatedListItem}
+              transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.3 }}
+            >
+              <h4
+                data-cursor="hover"
+                className="hover:text-accent-light dark:hover:text-accent-dark transition-theme w-fit font-bold motion-reduce:transition-none"
+              >
+                {skill.label}
+              </h4>
+              <ul className="list-inside list-disc">
+                {displayedProjects.map((project) => {
+                  return <li key={project}>{project}</li>;
+                })}
+                {extraCount !== 0 && (
+                  <span>
+                    {language === 'en'
+                      ? `and ${extraCount} more...`
+                      : `et ${extraCount} de plus...`}{' '}
+                  </span>
+                )}
+              </ul>
+            </motion.li>
+          );
+        })}
+      </motion.ul>
+
+      {/* 
+      V1 - Progress bars
       <ul className="grid grid-cols-2 gap-2">
         {skillsList.map((skill) => {
           return (
@@ -39,6 +130,7 @@ const Skills = ({ className }: SkillsProps) => {
           );
         })}
       </ul>
+      */}
     </motion.section>
   );
 };

--- a/src/pages/resume/components/Skills.tsx
+++ b/src/pages/resume/components/Skills.tsx
@@ -69,7 +69,7 @@ const Skills = ({ className }: SkillsProps) => {
       </h3>
       {/* V2 - Projects display */}
       <motion.ul
-        className="grid grid-cols-2 gap-2"
+        className="grid grid-cols-3 gap-2"
         variants={shouldReduceMotion ? undefined : animatedList}
         initial="hidden"
         animate={isInView ? 'visible' : 'hidden'}
@@ -82,7 +82,7 @@ const Skills = ({ className }: SkillsProps) => {
           return (
             <motion.li
               key={id}
-              className="py-2"
+              className="border-accent-primary-light dark:border-accent-primary-dark rounded-sm border px-2 py-2"
               variants={animatedListItem}
               transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.3 }}
             >

--- a/src/pages/resume/components/Skills.tsx
+++ b/src/pages/resume/components/Skills.tsx
@@ -67,9 +67,9 @@ const Skills = ({ className }: SkillsProps) => {
       <h3 className="border-b-accent-light dark:border-b-accent-dark transition-theme mb-4 w-fit border-b-2 font-bold motion-reduce:transition-none">
         {language === 'en' ? 'Skills' : 'Compétences'}
       </h3>
-      {/* V2 - Projects display */}
+
       <motion.ul
-        className="grid grid-cols-3 gap-2"
+        className="grid grid-cols-2 gap-2 lg:grid-cols-3"
         variants={shouldReduceMotion ? undefined : animatedList}
         initial="hidden"
         animate={isInView ? 'visible' : 'hidden'}
@@ -82,55 +82,36 @@ const Skills = ({ className }: SkillsProps) => {
           return (
             <motion.li
               key={id}
-              className="border-accent-primary-light dark:border-accent-primary-dark rounded-sm border px-2 py-2"
+              data-cursor="hover"
+              className="border-primary hover:border-accent-primary-light transition-theme dark:hover:border-accent-primary-dark group rounded-sm border px-2 py-2 motion-reduce:transition-none"
               variants={animatedListItem}
               transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.3 }}
             >
-              <h4
-                data-cursor="hover"
-                className="hover:text-accent-light dark:hover:text-accent-dark transition-theme w-fit font-bold motion-reduce:transition-none"
-              >
+              <h4 className="group-hover:text-accent-light dark:group-hover:text-accent-dark transition-theme w-fit font-bold motion-reduce:transition-none">
                 {skill.label}
               </h4>
               <ul className="list-inside list-disc">
-                {displayedProjects.map((project) => {
-                  return <li key={project}>{project}</li>;
-                })}
-                {extraCount !== 0 && (
-                  <span>
-                    {language === 'en'
-                      ? `and ${extraCount} more...`
-                      : `et ${extraCount} de plus...`}{' '}
-                  </span>
+                {skill.projects.length === 0 ? (
+                  <li>{language === 'en' ? 'Still learning' : 'En cours'}</li>
+                ) : (
+                  <>
+                    {displayedProjects.map((project) => {
+                      return <li key={project}>{project}</li>;
+                    })}
+                    {extraCount !== 0 && (
+                      <span>
+                        {language === 'en'
+                          ? `and ${extraCount} more...`
+                          : `et ${extraCount} de plus...`}{' '}
+                      </span>
+                    )}
+                  </>
                 )}
               </ul>
             </motion.li>
           );
         })}
       </motion.ul>
-
-      {/* 
-      V1 - Progress bars
-      <ul className="grid grid-cols-2 gap-2">
-        {skillsList.map((skill) => {
-          return (
-            <li key={skill.id} className="py-2">
-              <h4 className="w-fit font-bold">{skill.label}</h4>
-              <div className="border-accent-light dark:border-accent-dark transition-theme h-2.5 w-full rounded-full border p-0.5 motion-reduce:transition-none">
-                <motion.div
-                  animate={{ width: isInView ? `${skill.level}%` : '0%' }}
-                  initial={{ width: '0%' }}
-                  transition={
-                    shouldReduceMotion ? { duration: 0 } : { duration: 2, ease: 'easeInOut' }
-                  }
-                  className="bg-accent-light dark:bg-accent-dark transition-theme mr-auto h-full rounded-full motion-reduce:transition-none"
-                />
-              </div>
-            </li>
-          );
-        })}
-      </ul>
-      */}
     </motion.section>
   );
 };

--- a/src/pages/resume/components/Skills.tsx
+++ b/src/pages/resume/components/Skills.tsx
@@ -1,12 +1,12 @@
 import { motion, useInView, useReducedMotion } from 'motion/react';
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useLanguage } from '../../../contexts/LanguageContext';
 import { projectsDataEn } from '../../projects/data/projectsData.en';
 import { projectsDataFr } from '../../projects/data/projectsData.fr';
-import type { TechMap } from '../../projects/data/projectsDataType';
 import { skillsDataEN } from '../data/profileData.en';
 import { skillsDataFR } from '../data/profileData.fr';
-import type { SkillsProps } from '../data/profileDataType';
+import type { SkillProjects, SkillsProps, TechMap } from '../data/profileDataType';
+import SkillsDialog from './SkillsDialog';
 
 const Skills = ({ className }: SkillsProps) => {
   const shouldReduceMotion = useReducedMotion();
@@ -18,6 +18,14 @@ const Skills = ({ className }: SkillsProps) => {
 
   const sectionRef = useRef(null);
   const isInView = useInView(sectionRef, { amount: 0.2, once: true });
+
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [focusedSkill, setFocusedSkill] = useState<SkillProjects | null>(null);
+
+  const handleClick = (skill: SkillProjects) => {
+    setIsOpen(true);
+    setFocusedSkill(skill);
+  };
 
   const animatedList = {
     hidden: { opacity: 0 },
@@ -60,59 +68,68 @@ const Skills = ({ className }: SkillsProps) => {
   }, [skillsList, projectsList]);
 
   return (
-    <motion.section
-      ref={sectionRef}
-      className={`border-primary transition-theme rounded-lg border px-2 py-2 motion-reduce:transition-none ${className} `}
-    >
-      <h3 className="border-b-accent-light dark:border-b-accent-dark transition-theme mb-4 w-fit border-b-2 font-bold motion-reduce:transition-none">
-        {language === 'en' ? 'Skills' : 'Compétences'}
-      </h3>
-
-      <motion.ul
-        className="grid grid-cols-2 gap-2 lg:grid-cols-3"
-        variants={shouldReduceMotion ? undefined : animatedList}
-        initial="hidden"
-        animate={isInView ? 'visible' : 'hidden'}
+    <>
+      <motion.section
+        ref={sectionRef}
+        className={`border-primary transition-theme rounded-lg border px-2 py-2 motion-reduce:transition-none ${className} `}
       >
-        {technologiesMap.map(([id, skill]) => {
-          const maxProjectsDisplayed = 2;
-          const displayedProjects = skill.projects.slice(0, maxProjectsDisplayed);
-          const extraCount = Math.max(skill.projects.length - maxProjectsDisplayed, 0);
+        <h3 className="border-b-accent-light dark:border-b-accent-dark transition-theme mb-4 w-fit border-b-2 font-bold motion-reduce:transition-none">
+          {language === 'en' ? 'Skills' : 'Compétences'}
+        </h3>
 
-          return (
-            <motion.li
-              key={id}
-              data-cursor="hover"
-              className="border-primary hover:border-accent-primary-light transition-theme dark:hover:border-accent-primary-dark group rounded-sm border px-2 py-2 motion-reduce:transition-none"
-              variants={animatedListItem}
-              transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.3 }}
-            >
-              <h4 className="group-hover:text-accent-light dark:group-hover:text-accent-dark transition-theme w-fit font-bold motion-reduce:transition-none">
-                {skill.label}
-              </h4>
-              <ul className="list-inside list-disc">
-                {skill.projects.length === 0 ? (
-                  <li>{language === 'en' ? 'Still learning' : 'En cours'}</li>
-                ) : (
-                  <>
-                    {displayedProjects.map((project) => {
-                      return <li key={project}>{project}</li>;
-                    })}
-                    {extraCount !== 0 && (
-                      <span>
-                        {language === 'en'
-                          ? `and ${extraCount} more...`
-                          : `et ${extraCount} de plus...`}{' '}
-                      </span>
+        <motion.ul
+          className="grid grid-cols-2 gap-2 lg:grid-cols-3"
+          variants={shouldReduceMotion ? undefined : animatedList}
+          initial="hidden"
+          animate={isInView ? 'visible' : 'hidden'}
+        >
+          {technologiesMap.map(([id, skill]) => {
+            const maxProjectsDisplayed = 3;
+            const displayedProjects = skill.projects.slice(0, maxProjectsDisplayed);
+            const extraCount = Math.max(skill.projects.length - maxProjectsDisplayed, 0);
+
+            return (
+              <motion.li
+                key={id}
+                data-cursor="hover"
+                className="border-primary hover:border-accent-primary-light transition-theme dark:hover:border-accent-primary-dark group rounded-sm border motion-reduce:transition-none"
+                variants={animatedListItem}
+                transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.3 }}
+              >
+                <button
+                  type="button"
+                  className="flex h-full w-full flex-col justify-start px-2 py-2 text-start"
+                  onClick={() => handleClick(skill)}
+                >
+                  <h4 className="group-hover:text-accent-light dark:group-hover:text-accent-dark transition-theme w-fit font-bold motion-reduce:transition-none">
+                    {skill.label}
+                  </h4>
+                  <ul className="list-inside list-disc text-sm">
+                    {skill.projects.length === 0 ? (
+                      <span>{language === 'en' ? 'Still learning' : 'En cours'}</span>
+                    ) : (
+                      <>
+                        {displayedProjects.map((project) => {
+                          return <li key={project}>{project}</li>;
+                        })}
+                        {extraCount !== 0 && (
+                          <span>
+                            {language === 'en'
+                              ? `and ${extraCount} more...`
+                              : `et ${extraCount} de plus...`}{' '}
+                          </span>
+                        )}
+                      </>
                     )}
-                  </>
-                )}
-              </ul>
-            </motion.li>
-          );
-        })}
-      </motion.ul>
-    </motion.section>
+                  </ul>
+                </button>
+              </motion.li>
+            );
+          })}
+        </motion.ul>
+      </motion.section>
+      <SkillsDialog isOpen={isOpen} setIsOpen={setIsOpen} focusedSkill={focusedSkill} />
+    </>
   );
 };
 

--- a/src/pages/resume/components/SkillsDialog.tsx
+++ b/src/pages/resume/components/SkillsDialog.tsx
@@ -12,7 +12,7 @@ const SkillsDialog = ({ isOpen, setIsOpen, focusedSkill }: SkillsDialogProps) =>
       <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
         <DialogPanel className="border-primary bg-global-secondary max-h-[80dvh] w-[100dvw] max-w-4xl space-y-4 overflow-y-auto rounded-2xl border-3 p-3 sm:w-[80dvw] sm:p-8 lg:p-12">
           <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
-            <DialogTitle className="text-primary transition-theme border-accent-light dark:border-accent-dark rounded-sm border-2 p-2 font-bold uppercase motion-reduce:transition-none">
+            <DialogTitle className="text-primary transition-theme border-accent-light dark:border-accent-dark w-fit rounded-sm border-2 p-2 font-bold uppercase motion-reduce:transition-none">
               {focusedSkill?.label}
             </DialogTitle>
 
@@ -37,6 +37,22 @@ const SkillsDialog = ({ isOpen, setIsOpen, focusedSkill }: SkillsDialogProps) =>
 
           <hr className="text-primary" />
 
+          {/* Mobile - Simple */}
+          <div className="sm:hidden">
+            {focusedSkill?.projects.length === 0 ? (
+              <span className="text-primary">
+                {language === 'en' ? 'Currently learning' : "En cours d'apprentissage"}
+              </span>
+            ) : (
+              <ul className="text-primary list-inside list-disc">
+                {focusedSkill?.projects.map((project) => {
+                  return <li key={project}>{project}</li>;
+                })}
+              </ul>
+            )}
+          </div>
+
+          {/* Desktop - Octopus */}
           <div className="relative hidden min-h-[400px] w-full items-center justify-center py-4 sm:flex">
             <span className="text-primary border-primary bg-global-secondary absolute z-10 rounded-lg border px-6 py-3 text-lg font-semibold shadow-lg">
               {focusedSkill?.label}

--- a/src/pages/resume/components/SkillsDialog.tsx
+++ b/src/pages/resume/components/SkillsDialog.tsx
@@ -1,0 +1,81 @@
+import { Dialog, DialogPanel, DialogTitle } from '@headlessui/react';
+import IconWrapper from '../../../components/ui/IconWrapper';
+import { CloseIcon } from '../../../components/ui/Icons';
+import { useLanguage } from '../../../contexts/LanguageContext';
+import type { SkillsDialogProps } from '../data/profileDataType';
+
+const SkillsDialog = ({ isOpen, setIsOpen, focusedSkill }: SkillsDialogProps) => {
+  const { language } = useLanguage();
+
+  return (
+    <Dialog open={isOpen} onClose={() => setIsOpen(false)} className="relative z-50">
+      <div className="fixed inset-0 flex w-screen items-center justify-center p-4">
+        <DialogPanel className="border-primary bg-global-secondary max-h-[80dvh] w-[100dvw] max-w-4xl space-y-4 overflow-y-auto rounded-2xl border-3 p-3 sm:w-[80dvw] sm:p-8 lg:p-12">
+          <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+            <DialogTitle className="text-primary transition-theme border-accent-light dark:border-accent-dark rounded-sm border-2 p-2 font-bold uppercase motion-reduce:transition-none">
+              {focusedSkill?.label}
+            </DialogTitle>
+
+            <button
+              type="button"
+              data-cursor="hover"
+              className="order-first mx-auto sm:order-none sm:mx-0"
+              onClick={() => setIsOpen(false)}
+              aria-label={language === 'en' ? 'Close window' : 'Fermer la fenêtre'}
+            >
+              <IconWrapper
+                variant="rounded-button"
+                wrapperClassName="shadow-[0_0_12px_4px_var(--color-btn-primary-hover-light)] dark:shadow-[0_0_12px_4px_var(--color-btn-primary-hover-dark)] size-10"
+              >
+                <CloseIcon />
+                <span className="sr-only">
+                  {language === 'en' ? 'Close window' : 'Fermer la fenêtre'}
+                </span>
+              </IconWrapper>
+            </button>
+          </div>
+
+          <hr className="text-primary" />
+
+          <div className="relative hidden min-h-[400px] w-full items-center justify-center py-4 sm:flex">
+            <span className="text-primary border-primary bg-global-secondary absolute z-10 rounded-lg border px-6 py-3 text-lg font-semibold shadow-lg">
+              {focusedSkill?.label}
+            </span>
+            {focusedSkill?.projects.map((project, index) => {
+              const totalProjects = focusedSkill.projects.length;
+              const angle = (360 / totalProjects) * index - 90;
+              const radius = 170;
+
+              const x = radius * Math.cos((angle * Math.PI) / 180);
+              const y = radius * Math.sin((angle * Math.PI) / 180);
+
+              return (
+                <div
+                  key={project}
+                  className="bg-global-secondary absolute -translate-x-1/2 -translate-y-1/2 transform"
+                  style={{
+                    left: `calc(50% + ${x}px)`,
+                    top: `calc(50% + ${y}px)`,
+                  }}
+                >
+                  <span className="text-primary bg-global-secondary relative z-10 rounded px-2">
+                    {project}
+                  </span>
+                  <div
+                    className="bg-primary absolute top-1/2 left-1/2 w-0.5 origin-top opacity-30"
+                    style={{
+                      height: `${radius}px`,
+                      transform: `rotate(${angle + 90}deg)`,
+                    }}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </DialogPanel>
+      </div>
+    </Dialog>
+  );
+};
+
+export default SkillsDialog;

--- a/src/pages/resume/components/SoftSkills.tsx
+++ b/src/pages/resume/components/SoftSkills.tsx
@@ -37,7 +37,7 @@ const SoftSkills = ({ className }: SoftSkillsProps) => {
       </h3>
       <motion.ul
         ref={ref}
-        className="grid list-inside list-disc grid-cols-2 gap-2"
+        className="grid list-inside list-disc grid-cols-2 gap-2 lg:grid-cols-3"
         variants={shouldReduceMotion ? undefined : animatedList}
         initial="hidden"
         animate={isInView ? 'visible' : 'hidden'}

--- a/src/pages/resume/data/educationData.en.ts
+++ b/src/pages/resume/data/educationData.en.ts
@@ -4,7 +4,7 @@ export const educationDataEN: TimelineItem[] = [
   {
     id: 'codecademy-wcs-2025',
     type: 'training',
-    company: 'Codecademy & Wild Code School',
+    company: 'Wild Code School & Codecademy',
     link: 'https://www.wildcodeschool.com/',
     position: 'Full-Stack Web Developer',
     location: 'Remote',
@@ -22,20 +22,29 @@ export const educationDataEN: TimelineItem[] = [
     ],
     stack: [
       {
+        category: 'language',
         name: 'Languages',
         content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
-        content: ['React', 'Express', 'Tailwind CSS'],
+        content: ['React', 'Express', 'TailwindCSS'],
       },
       {
+        category: 'database',
         name: 'Databases',
         content: ['MySQL'],
       },
       {
+        category: 'tool',
         name: 'Tools',
         content: ['Git', 'GitHub', 'Excalidraw', 'Figma', 'Trello', 'Motion'],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility', 'Agile', 'REST API'],
       },
     ],
     keywords: [
@@ -91,6 +100,7 @@ export const educationDataEN: TimelineItem[] = [
     ],
     stack: [
       {
+        category: 'tool',
         name: 'Tools',
         content: ['Matlab', 'SolidWorks', 'Catia', 'Ansys'],
       },

--- a/src/pages/resume/data/educationData.fr.ts
+++ b/src/pages/resume/data/educationData.fr.ts
@@ -4,7 +4,7 @@ export const educationDataFR: TimelineItem[] = [
   {
     id: 'codecademy-wcs-2025',
     type: 'formation',
-    company: 'Codecademy & Wild Code School',
+    company: 'Wild Code School & Codecademy',
     link: 'https://www.wildcodeschool.com/',
     position: 'Développeur full-stack',
     location: 'Remote',
@@ -22,23 +22,31 @@ export const educationDataFR: TimelineItem[] = [
     ],
     stack: [
       {
-        name: 'Languages',
+        category: 'language',
+        name: 'Langages',
         content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
-        content: ['React', 'Express', 'Tailwind CSS'],
+        content: ['React', 'Express', 'TailwindCSS'],
       },
       {
-        name: 'Databases',
+        category: 'database',
+        name: 'Bases de données',
         content: ['MySQL'],
       },
       {
+        category: 'tool',
         name: 'Outils',
         content: ['Git', 'GitHub', 'Excalidraw', 'Figma', 'Trello', 'Motion'],
       },
+      {
+        category: 'method',
+        name: 'Méthodes',
+        content: ['Responsive', 'Accessibility', 'Agile', 'REST API'],
+      },
     ],
-
     keywords: [
       'développement web',
       'front end',
@@ -92,6 +100,7 @@ export const educationDataFR: TimelineItem[] = [
     ],
     stack: [
       {
+        category: 'tool',
         name: 'Outils',
         content: ['Matlab', 'SolidWorks', 'Catia', 'Ansys'],
       },

--- a/src/pages/resume/data/experiencesData.en.ts
+++ b/src/pages/resume/data/experiencesData.en.ts
@@ -24,20 +24,29 @@ export const experiencesDataEN: TimelineItem[] = [
     ],
     stack: [
       {
+        category: 'language',
         name: 'Languages',
         content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
-        content: ['React', 'Express', 'Tailwind CSS'],
+        content: ['React', 'Express', 'TailwindCSS'],
       },
       {
+        category: 'database',
         name: 'Databases',
         content: ['MySQL'],
       },
       {
+        category: 'tool',
         name: 'Tools',
         content: ['Git', 'GitHub', 'Excalidraw', 'Figma', 'Trello', 'Motion'],
+      },
+      {
+        category: 'method',
+        name: 'Methods',
+        content: ['Responsive', 'Accessibility', 'Agile', 'REST API'],
       },
     ],
     keywords: [
@@ -134,6 +143,7 @@ export const experiencesDataEN: TimelineItem[] = [
     ],
     stack: [
       {
+        category: 'tool',
         name: 'Tools',
         content: ['AutoCAD', 'Rhinoceros', 'Catia', 'Gantt'],
       },
@@ -173,6 +183,7 @@ export const experiencesDataEN: TimelineItem[] = [
     ],
     stack: [
       {
+        category: 'tool',
         name: 'Tools',
         content: ['AutoCAD', 'Rhinoceros', 'Catia', 'Gantt'],
       },

--- a/src/pages/resume/data/experiencesData.fr.ts
+++ b/src/pages/resume/data/experiencesData.fr.ts
@@ -24,20 +24,29 @@ export const experiencesDataFR: TimelineItem[] = [
     ],
     stack: [
       {
-        name: 'Languages',
+        category: 'language',
+        name: 'Langages',
         content: ['HTML', 'CSS', 'JavaScript', 'TypeScript'],
       },
       {
+        category: 'framework',
         name: 'Frameworks',
-        content: ['React', 'Express', 'Tailwind CSS'],
+        content: ['React', 'Express', 'TailwindCSS'],
       },
       {
-        name: 'Databases',
+        category: 'database',
+        name: 'Bases de données',
         content: ['MySQL'],
       },
       {
+        category: 'tool',
         name: 'Outils',
         content: ['Git', 'GitHub', 'Excalidraw', 'Figma', 'Trello', 'Motion'],
+      },
+      {
+        category: 'method',
+        name: 'Méthodes',
+        content: ['Responsive', 'Accessibility', 'Agile', 'REST API'],
       },
     ],
     keywords: [
@@ -134,6 +143,7 @@ export const experiencesDataFR: TimelineItem[] = [
     ],
     stack: [
       {
+        category: 'tool',
         name: 'Outils',
         content: ['AutoCAD', 'Rhinoceros', 'Catia', 'Gantt'],
       },
@@ -173,6 +183,7 @@ export const experiencesDataFR: TimelineItem[] = [
     ],
     stack: [
       {
+        category: 'tool',
         name: 'Outils',
         content: ['AutoCAD', 'Rhinoceros', 'Catia', 'Gantt'],
       },

--- a/src/pages/resume/data/profileData.en.ts
+++ b/src/pages/resume/data/profileData.en.ts
@@ -1,30 +1,30 @@
 import type { HardSkill, LanguageLevel, SoftSkill } from './profileDataType';
 
 export const skillsDataEN: HardSkill[] = [
-  { id: 'html', label: 'HTML', category: 'language', level: 90 },
-  { id: 'css', label: 'CSS', category: 'language', level: 75 },
-  { id: 'javascript', label: 'JavaScript', category: 'language', level: 75 },
-  { id: 'typescript', label: 'TypeScript', category: 'language', level: 65 },
+  { id: 'html', label: 'HTML', category: 'language' },
+  { id: 'css', label: 'CSS', category: 'language' },
+  { id: 'javascript', label: 'JavaScript', category: 'language' },
+  { id: 'typescript', label: 'TypeScript', category: 'language' },
 
-  { id: 'react', label: 'React', category: 'framework', level: 70 },
-  { id: 'tailwind', label: 'TailwindCSS', category: 'framework', level: 70 },
-  { id: 'node', label: 'Node.js', category: 'framework', level: 65 },
-  { id: 'express', label: 'Express.js', category: 'framework', level: 65 },
+  { id: 'react', label: 'React', category: 'framework' },
+  { id: 'tailwind', label: 'TailwindCSS', category: 'framework' },
+  { id: 'node', label: 'Node.js', category: 'framework' },
+  { id: 'express', label: 'Express.js', category: 'framework' },
 
-  { id: 'mysql', label: 'MySQL', category: 'database', level: 60 },
+  { id: 'mysql', label: 'MySQL', category: 'database' },
 
-  { id: 'git', label: 'Git', category: 'tool', level: 85 },
-  { id: 'github', label: 'GitHub', category: 'tool', level: 85 },
-  { id: 'framer-motion', label: 'Framer Motion', category: 'tool', level: 50 },
-  { id: 'tests', label: 'Mocha - Chai', category: 'tool', level: 15 },
-  { id: 'docker', label: 'Docker', category: 'tool', level: 15 },
+  { id: 'git', label: 'Git', category: 'tool' },
+  { id: 'github', label: 'GitHub', category: 'tool' },
+  { id: 'framer motion', label: 'Framer Motion', category: 'tool' },
+  { id: 'tests', label: 'Mocha - Chai', category: 'tool' },
+  { id: 'docker', label: 'Docker', category: 'tool' },
 
-  { id: 'responsive', label: 'Responsive', category: 'method', level: 75 },
-  { id: 'accessibility', label: 'Accessibility', category: 'method', level: 60 },
-  { id: 'agile', label: 'Agile', category: 'method', level: 65 },
-  { id: 'tdd', label: 'TDD', category: 'method', level: 15 },
-  { id: 'api', label: 'REST API', category: 'method', level: 70 },
-  { id: 'ci-cd', label: 'CI/CD', category: 'method', level: 15 },
+  { id: 'responsive', label: 'Responsive', category: 'method' },
+  { id: 'accessibility', label: 'Accessibility', category: 'method' },
+  { id: 'agile', label: 'Agile', category: 'method' },
+  { id: 'tdd', label: 'TDD', category: 'method' },
+  { id: 'api', label: 'REST API', category: 'method' },
+  { id: 'ci-cd', label: 'CI/CD', category: 'method' },
 ];
 
 export const softSkillsDataEN: SoftSkill[] = [

--- a/src/pages/resume/data/profileData.en.ts
+++ b/src/pages/resume/data/profileData.en.ts
@@ -8,8 +8,8 @@ export const skillsDataEN: HardSkill[] = [
 
   { id: 'react', label: 'React', category: 'framework' },
   { id: 'tailwind', label: 'TailwindCSS', category: 'framework' },
-  { id: 'node', label: 'Node.js', category: 'framework' },
-  { id: 'express', label: 'Express.js', category: 'framework' },
+  { id: 'node', label: 'Node', category: 'framework' },
+  { id: 'express', label: 'Express', category: 'framework' },
 
   { id: 'mysql', label: 'MySQL', category: 'database' },
 
@@ -18,12 +18,13 @@ export const skillsDataEN: HardSkill[] = [
   { id: 'framer motion', label: 'Framer Motion', category: 'tool' },
   { id: 'tests', label: 'Mocha - Chai', category: 'tool' },
   { id: 'docker', label: 'Docker', category: 'tool' },
+  { id: 'monorepo', label: 'Monorepo', category: 'tool' },
 
   { id: 'responsive', label: 'Responsive', category: 'method' },
   { id: 'accessibility', label: 'Accessibility', category: 'method' },
   { id: 'agile', label: 'Agile', category: 'method' },
   { id: 'tdd', label: 'TDD', category: 'method' },
-  { id: 'api', label: 'REST API', category: 'method' },
+  { id: 'rest api', label: 'REST API', category: 'method' },
   { id: 'ci-cd', label: 'CI/CD', category: 'method' },
 ];
 

--- a/src/pages/resume/data/profileData.fr.ts
+++ b/src/pages/resume/data/profileData.fr.ts
@@ -7,8 +7,8 @@ export const skillsDataFR: HardSkill[] = [
 
   { id: 'react', label: 'React', category: 'framework' },
   { id: 'tailwind', label: 'TailwindCSS', category: 'framework' },
-  { id: 'node', label: 'Node.js', category: 'framework' },
-  { id: 'express', label: 'Express.js', category: 'framework' },
+  { id: 'node', label: 'Node', category: 'framework' },
+  { id: 'express', label: 'Express', category: 'framework' },
 
   { id: 'mysql', label: 'MySQL', category: 'database' },
 
@@ -17,12 +17,13 @@ export const skillsDataFR: HardSkill[] = [
   { id: 'framer motion', label: 'Framer Motion', category: 'tool' },
   { id: 'tests', label: 'Mocha - Chai', category: 'tool' },
   { id: 'docker', label: 'Docker', category: 'tool' },
+  { id: 'monorepo', label: 'Monorepo', category: 'tool' },
 
   { id: 'responsive', label: 'Responsive', category: 'method' },
   { id: 'accessibility', label: 'Accessibilité', category: 'method' },
   { id: 'agile', label: 'Agile', category: 'method' },
   { id: 'tdd', label: 'TDD', category: 'method' },
-  { id: 'api', label: 'API REST', category: 'method' },
+  { id: 'rest api', label: 'REST API', category: 'method' },
   { id: 'ci-cd', label: 'CI/CD', category: 'method' },
 ];
 

--- a/src/pages/resume/data/profileData.fr.ts
+++ b/src/pages/resume/data/profileData.fr.ts
@@ -1,29 +1,29 @@
 import type { HardSkill, LanguageLevel, SoftSkill } from './profileDataType';
 export const skillsDataFR: HardSkill[] = [
-  { id: 'html', label: 'HTML', category: 'language', level: 90 },
-  { id: 'css', label: 'CSS', category: 'language', level: 75 },
-  { id: 'javascript', label: 'JavaScript', category: 'language', level: 75 },
-  { id: 'typescript', label: 'TypeScript', category: 'language', level: 65 },
+  { id: 'html', label: 'HTML', category: 'language' },
+  { id: 'css', label: 'CSS', category: 'language' },
+  { id: 'javascript', label: 'JavaScript', category: 'language' },
+  { id: 'typescript', label: 'TypeScript', category: 'language' },
 
-  { id: 'react', label: 'React', category: 'framework', level: 70 },
-  { id: 'tailwind', label: 'TailwindCSS', category: 'framework', level: 70 },
-  { id: 'node', label: 'Node.js', category: 'framework', level: 65 },
-  { id: 'express', label: 'Express.js', category: 'framework', level: 65 },
+  { id: 'react', label: 'React', category: 'framework' },
+  { id: 'tailwind', label: 'TailwindCSS', category: 'framework' },
+  { id: 'node', label: 'Node.js', category: 'framework' },
+  { id: 'express', label: 'Express.js', category: 'framework' },
 
-  { id: 'mysql', label: 'MySQL', category: 'database', level: 60 },
+  { id: 'mysql', label: 'MySQL', category: 'database' },
 
-  { id: 'git', label: 'Git', category: 'tool', level: 85 },
-  { id: 'github', label: 'GitHub', category: 'tool', level: 85 },
-  { id: 'framer-motion', label: 'Framer Motion', category: 'tool', level: 50 },
-  { id: 'tests', label: 'Mocha - Chai', category: 'tool', level: 15 },
-  { id: 'docker', label: 'Docker', category: 'tool', level: 15 },
+  { id: 'git', label: 'Git', category: 'tool' },
+  { id: 'github', label: 'GitHub', category: 'tool' },
+  { id: 'framer motion', label: 'Framer Motion', category: 'tool' },
+  { id: 'tests', label: 'Mocha - Chai', category: 'tool' },
+  { id: 'docker', label: 'Docker', category: 'tool' },
 
-  { id: 'responsive', label: 'Responsive', category: 'method', level: 75 },
-  { id: 'accessibility', label: 'Accessibilité', category: 'method', level: 60 },
-  { id: 'agile', label: 'Agile', category: 'method', level: 65 },
-  { id: 'tdd', label: 'TDD', category: 'method', level: 15 },
-  { id: 'api', label: 'API REST', category: 'method', level: 70 },
-  { id: 'ci-cd', label: 'CI/CD', category: 'method', level: 15 },
+  { id: 'responsive', label: 'Responsive', category: 'method' },
+  { id: 'accessibility', label: 'Accessibilité', category: 'method' },
+  { id: 'agile', label: 'Agile', category: 'method' },
+  { id: 'tdd', label: 'TDD', category: 'method' },
+  { id: 'api', label: 'API REST', category: 'method' },
+  { id: 'ci-cd', label: 'CI/CD', category: 'method' },
 ];
 
 export const softSkillsDataFR: SoftSkill[] = [

--- a/src/pages/resume/data/profileDataType.ts
+++ b/src/pages/resume/data/profileDataType.ts
@@ -7,6 +7,7 @@ export interface HardSkill {
 
 export interface SkillProjects {
   label: string;
+  category: 'language' | 'framework' | 'database' | 'tool' | 'method';
   projects: string[];
 }
 

--- a/src/pages/resume/data/profileDataType.ts
+++ b/src/pages/resume/data/profileDataType.ts
@@ -5,6 +5,21 @@ export interface HardSkill {
   icon?: string;
 }
 
+export interface SkillProjects {
+  label: string;
+  projects: string[];
+}
+
+export interface TechMap {
+  [key: string]: SkillProjects;
+}
+
+export interface SkillsDialogProps {
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  focusedSkill: SkillProjects | null;
+}
+
 export interface SkillsProps {
   className: string;
 }

--- a/src/pages/resume/data/profileDataType.ts
+++ b/src/pages/resume/data/profileDataType.ts
@@ -2,7 +2,6 @@ export interface HardSkill {
   id: string;
   label: string;
   category: 'language' | 'framework' | 'database' | 'tool' | 'method';
-  level: number;
   icon?: string;
 }
 

--- a/src/pages/resume/data/timelineDataType.ts
+++ b/src/pages/resume/data/timelineDataType.ts
@@ -1,4 +1,5 @@
 export interface Technology {
+  category: 'language' | 'framework' | 'database' | 'tool' | 'method';
   name: string;
   content: string[];
 }


### PR DESCRIPTION
## Feature: Resume Skills Redesign with Project-Based Display

### Description

This PR refactors the skills (hard skills) section on the Resume page. The previous progress bar system was removed in favor of a more objective and contextual approach: each skill now displays the list of projects in which it has been used. This change aims to provide a clearer picture of how each skill has been applied in real scenarios.

### Changes

- [x] Linked each skill (stack item) to all matching projects
- [x] Display a limited list of associated projects with basic entrance animation
- [x] Updated skills and stack data to support project linkage
- [x] Refactored Resume layout with a new responsive grid
- [x] Prepared data structure for future dynamic filtering of stacks
- [x] Created a `SkillsDialog` component:
  - Desktop: radial "octopus-style" layout showing related projects
  - Mobile: simplified vertical list for clarity
- [x] Separated skills into two groups:
  - Skills used in one or more projects
  - Skills not yet used in real projects (in progress)
- [x] Optimized performance using `useMemo` to compute skill-project matches without recalculating on each render

### Design Decisions

- Categorized skills (`language`, `framework`, `database`, `tool`, `method`) but deliberately chose not to visually separate them for clarity and compactness
- Dialog content adapts to screen size to improve UX across devices
- This layout highlights concrete usage over subjective evaluation, making skill relevance more transparent

### To Do Later

- [ ] Enable linking from a project in the dialog to its detailed view (not a priority for now)
- [ ] Add optional filtering by skill category if needed

